### PR TITLE
Set RequestMessage in matched StubbedResponse

### DIFF
--- a/Tool/SystemTestingTools/Internal/HttpCallInterceptor.cs
+++ b/Tool/SystemTestingTools/Internal/HttpCallInterceptor.cs
@@ -132,7 +132,11 @@ namespace SystemTestingTools.Internal
             if (match.Exception != null)
                 throw match.Exception;
 
-            return await match.Response.Clone(); // we clone because if the response is used more than one time, the content stream has been read and can't be read again
+            var clonedResponse = await match.Response.Clone(); // we clone because if the response is used more than one time, the content stream has been read and can't be read again
+            var clonedRequest = await request.Clone();
+
+            clonedResponse.RequestMessage = clonedRequest;
+            return clonedResponse;
         }
     }
 }


### PR DESCRIPTION
When running AcceptanceTests for error scenarios using Refit, it throws null reference exception. This is caused by refit trying to access response.RequestMessage.Method while response.RequestMessage is null.  This change resolves that issue by setting the original request as response.RequestMessage. It will also help if any tested code is accessing response.RequestMessage.

The refit method that throws null reference exception https://github.com/reactiveui/refit/blob/569108a65079d364647f06437f977df8145fc578/Refit/RefitSettings.cs#L233