### PR TITLE
Added example to display behaviour of AppendHttpCallStub when it is passed Complex Query Parameters

### DIFF
--- a/Examples/MovieProject/MovieProject.Logic/DTO/UserSearchModel.cs
+++ b/Examples/MovieProject/MovieProject.Logic/DTO/UserSearchModel.cs
@@ -1,0 +1,27 @@
+﻿namespace MovieProject.Logic.DTO
+{
+    using System.Text.Json.Serialization;
+
+    namespace MovieProject.Logic.Proxy.DTO
+    {
+
+        public class UserSearchModel
+        {
+            [JsonPropertyName("name")]
+            public string Name { get; set; }
+
+            [JsonPropertyName("username")]
+            public string Username { get; set; }
+
+            [JsonPropertyName("email")]
+            public string Email { get; set; }
+
+            [JsonPropertyName("phone")]
+            public string Phone { get; set; }
+
+            [JsonPropertyName("website")]
+            public string Website { get; set; }
+        }
+
+    }
+}

--- a/Examples/MovieProject/MovieProject.Logic/Extensions/UserMapperExtensions.cs
+++ b/Examples/MovieProject/MovieProject.Logic/Extensions/UserMapperExtensions.cs
@@ -1,0 +1,20 @@
+﻿using MovieProject.Logic.Proxy.DTO;
+
+namespace MovieProject.Logic.Extensions
+{
+    public static class UserMapperExtensions
+    {
+        public static UserSearchModel MapUserSearchModelDtoToProxyDto(
+            this DTO.MovieProject.Logic.Proxy.DTO.UserSearchModel searchModel)
+        {
+            return new UserSearchModel
+            {
+                Name = searchModel.Name,
+                Username = searchModel.Username,
+                Email = searchModel.Email,
+                Phone = searchModel.Phone,
+                Website = searchModel.Website
+            };
+        }
+    }
+}

--- a/Examples/MovieProject/MovieProject.Logic/MovieProject.Logic.csproj
+++ b/Examples/MovieProject/MovieProject.Logic/MovieProject.Logic.csproj
@@ -22,4 +22,8 @@
     <WCFMetadata Include="Connected Services" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Models\" />
+  </ItemGroup>
+
 </Project>

--- a/Examples/MovieProject/MovieProject.Logic/Proxy/DTO/UserSearchModel.cs
+++ b/Examples/MovieProject/MovieProject.Logic/Proxy/DTO/UserSearchModel.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.Json.Serialization;
+
+namespace MovieProject.Logic.Proxy.DTO
+{
+
+    public class UserSearchModel
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("username")]
+        public string Username { get; set; }
+
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+
+        [JsonPropertyName("website")]
+        public string Website { get; set; }
+    }
+
+}

--- a/Examples/MovieProject/MovieProject.Logic/Proxy/UserProxy.cs
+++ b/Examples/MovieProject/MovieProject.Logic/Proxy/UserProxy.cs
@@ -2,13 +2,17 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using MovieProject.Logic.Proxy.DTO;
 
 namespace MovieProject.Logic.Proxy
 {
     public interface IUserProxy
     {
         Task<DTO.User[]> GetUsers();
+        Task<DTO.User[]> GetSearchUsers(UserSearchModel searchModel);
     }
 
     public class UserProxy  : BaseProxy, IUserProxy
@@ -28,6 +32,22 @@ namespace MovieProject.Logic.Proxy
                 // any exceptions throwm in here will be wrapped inside a DownstreamException, will all the details of the request / response for investigation
                 // also applies the concept of anti-corruption layer, meaning we parse the external DTO inside the proxy, and only return valid / clean internal DTOs
 
+                if(status != HttpStatusCode.OK || users == null)
+                    throw new Exception("Unexpected response");
+
+                return users;
+            });
+
+            return result;
+        }
+        
+        public async Task<DTO.User[]> GetSearchUsers(UserSearchModel searchModel)
+        {
+            string serialisedQueryParameter = JsonSerializer.Serialize(searchModel);
+            string route = $"searchUsers?userSearchModel={serialisedQueryParameter}";
+
+            var result = await Send(HttpMethod.Get, route, (DTO.User[] users, HttpStatusCode status) =>
+            {
                 if(status != HttpStatusCode.OK || users == null)
                     throw new Exception("Unexpected response");
 

--- a/Examples/MovieProject/MovieProject.Logic/Service/UserService.cs
+++ b/Examples/MovieProject/MovieProject.Logic/Service/UserService.cs
@@ -1,13 +1,15 @@
-﻿using MovieProject.Logic.Proxy;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MovieProject.Logic.Proxy;
+using MovieProject.Logic.Proxy.DTO;
 
-namespace MovieProject.Logic
+namespace MovieProject.Logic.Service
 {
     public interface IUserService
     {
         Task<List<string>> GetUsers();
+        Task<List<string>> GetSearchUsers(UserSearchModel searchModel);
     }
 
     public class UserService : IUserService
@@ -22,6 +24,13 @@ namespace MovieProject.Logic
         public async Task<List<string>> GetUsers()
         {
             var users = await _userProxy.GetUsers();
+
+            return users.Select(c=> c.Name).OrderBy(c=> c).ToList();
+        }
+
+        public async Task<List<string>> GetSearchUsers(UserSearchModel searchModel)
+        {
+            var users = await _userProxy.GetSearchUsers(searchModel);
 
             return users.Select(c=> c.Name).OrderBy(c=> c).ToList();
         }

--- a/Examples/MovieProject/MovieProject.Tests/MovieProject.IsolatedTests/ComponentTesting/GetUserHappyTests.cs
+++ b/Examples/MovieProject/MovieProject.Tests/MovieProject.IsolatedTests/ComponentTesting/GetUserHappyTests.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using MovieProject.Logic.DTO.MovieProject.Logic.Proxy.DTO;
+using Newtonsoft.Json;
 using SystemTestingTools;
 using Xunit;
 
@@ -15,7 +17,8 @@ namespace IsolatedTests.ComponentTestings
     {
         private readonly TestServerFixture Fixture;
 
-        private static string Url = "https://jsonplaceholder.typicode.com/users";
+        private static string GetUrl = "https://jsonplaceholder.typicode.com/users";
+        private static string SearchUrl = "https://jsonplaceholder.typicode.com/searchUsers";
 
         public GetUserHappyTests(TestServerFixture fixture)
         {        
@@ -35,7 +38,7 @@ namespace IsolatedTests.ComponentTestings
                 dto[0].Name = "Changed in code";
             });
 
-            client.AppendHttpCallStub(HttpMethod.Get, new System.Uri(Url), response);
+            client.AppendHttpCallStub(HttpMethod.Get, new System.Uri(GetUrl), response);
 
             // act
             var httpResponse = await client.GetAsync("/api/users");
@@ -49,7 +52,7 @@ namespace IsolatedTests.ComponentTestings
                 // assert outgoing
                 var outgoingRequests = client.GetSessionOutgoingRequests();
                 outgoingRequests.Count.Should().Be(1);
-                outgoingRequests[0].GetEndpoint().Should().Be($"GET {Url}");
+                outgoingRequests[0].GetEndpoint().Should().Be($"GET {GetUrl}");
                 outgoingRequests[0].GetHeaderValue("Referer").Should().Be(MovieProject.Logic.Constants.Website);
 
                 // assert return
@@ -67,6 +70,50 @@ namespace IsolatedTests.ComponentTestings
                 list[7].Should().Be("Mrs. Dennis Schulist");
                 list[8].Should().Be("Nicholas Runolfsdottir V");
                 list[9].Should().Be("Patricia Lebsack");
+            }
+        }
+        
+        [Fact]
+        public async Task When_UserSearchesWithValidParameters_Then_ReturnListProperly()
+        {
+            // arrange
+            var complexParameter = new UserSearchModel
+            {
+                Username = "Bret",
+            };
+            var serialisedComplexParameters = JsonConvert.SerializeObject(complexParameter);
+            var expectedResponse = new List<string>()
+            {
+                "Leanne Graham"
+            };
+            
+            var client = Fixture.Server.CreateClient();
+            client.CreateSession();
+            var response = ResponseFactory.FromFiddlerLikeResponseFile($"{Fixture.StubsFolder}/UserApi/Real_Responses/Happy/200_SearchListUsers.txt");
+
+            client.AppendHttpCallStub(HttpMethod.Get, new System.Uri(@$"{SearchUrl}?userSearchModel={serialisedComplexParameters}"), response);
+
+            // act
+            var httpResponse = await client.GetAsync("/api/users");
+
+            using (new AssertionScope())
+            {
+                // assert logs
+                var logs = client.GetSessionLogs();
+                logs.Should().BeEmpty();
+
+                // assert outgoing
+                var outgoingRequests = client.GetSessionOutgoingRequests();
+                outgoingRequests.Count.Should().Be(1);
+                outgoingRequests[0].GetEndpoint().Should().Be($"GET {SearchUrl}");
+                outgoingRequests[0].GetHeaderValue("Referer").Should().Be(MovieProject.Logic.Constants.Website);
+
+                // assert return
+                httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+                var list = await httpResponse.ReadJsonBody<List<string>>();
+                list.Count.Should().Be(1);
+                list.Should().BeEquivalentTo(expectedResponse);
             }
         }
     }

--- a/Examples/MovieProject/MovieProject.Tests/MovieProject.IsolatedTests/ComponentTesting/GetUserHappyTests.cs
+++ b/Examples/MovieProject/MovieProject.Tests/MovieProject.IsolatedTests/ComponentTesting/GetUserHappyTests.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using MovieProject.Logic.DTO.MovieProject.Logic.Proxy.DTO;
-using Newtonsoft.Json;
 using SystemTestingTools;
 using Xunit;
 
@@ -17,8 +15,7 @@ namespace IsolatedTests.ComponentTestings
     {
         private readonly TestServerFixture Fixture;
 
-        private static string GetUrl = "https://jsonplaceholder.typicode.com/users";
-        private static string SearchUrl = "https://jsonplaceholder.typicode.com/searchUsers";
+        private static string Url = "https://jsonplaceholder.typicode.com/users";
 
         public GetUserHappyTests(TestServerFixture fixture)
         {        
@@ -38,7 +35,7 @@ namespace IsolatedTests.ComponentTestings
                 dto[0].Name = "Changed in code";
             });
 
-            client.AppendHttpCallStub(HttpMethod.Get, new System.Uri(GetUrl), response);
+            client.AppendHttpCallStub(HttpMethod.Get, new System.Uri(Url), response);
 
             // act
             var httpResponse = await client.GetAsync("/api/users");
@@ -52,7 +49,7 @@ namespace IsolatedTests.ComponentTestings
                 // assert outgoing
                 var outgoingRequests = client.GetSessionOutgoingRequests();
                 outgoingRequests.Count.Should().Be(1);
-                outgoingRequests[0].GetEndpoint().Should().Be($"GET {GetUrl}");
+                outgoingRequests[0].GetEndpoint().Should().Be($"GET {Url}");
                 outgoingRequests[0].GetHeaderValue("Referer").Should().Be(MovieProject.Logic.Constants.Website);
 
                 // assert return
@@ -70,50 +67,6 @@ namespace IsolatedTests.ComponentTestings
                 list[7].Should().Be("Mrs. Dennis Schulist");
                 list[8].Should().Be("Nicholas Runolfsdottir V");
                 list[9].Should().Be("Patricia Lebsack");
-            }
-        }
-        
-        [Fact]
-        public async Task When_UserSearchesWithValidParameters_Then_ReturnListProperly()
-        {
-            // arrange
-            var complexParameter = new UserSearchModel
-            {
-                Username = "Bret",
-            };
-            var serialisedComplexParameters = JsonConvert.SerializeObject(complexParameter);
-            var expectedResponse = new List<string>()
-            {
-                "Leanne Graham"
-            };
-            
-            var client = Fixture.Server.CreateClient();
-            client.CreateSession();
-            var response = ResponseFactory.FromFiddlerLikeResponseFile($"{Fixture.StubsFolder}/UserApi/Real_Responses/Happy/200_SearchListUsers.txt");
-
-            client.AppendHttpCallStub(HttpMethod.Get, new System.Uri(@$"{SearchUrl}?userSearchModel={serialisedComplexParameters}"), response);
-
-            // act
-            var httpResponse = await client.GetAsync("/api/users");
-
-            using (new AssertionScope())
-            {
-                // assert logs
-                var logs = client.GetSessionLogs();
-                logs.Should().BeEmpty();
-
-                // assert outgoing
-                var outgoingRequests = client.GetSessionOutgoingRequests();
-                outgoingRequests.Count.Should().Be(1);
-                outgoingRequests[0].GetEndpoint().Should().Be($"GET {SearchUrl}");
-                outgoingRequests[0].GetHeaderValue("Referer").Should().Be(MovieProject.Logic.Constants.Website);
-
-                // assert return
-                httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-
-                var list = await httpResponse.ReadJsonBody<List<string>>();
-                list.Count.Should().Be(1);
-                list.Should().BeEquivalentTo(expectedResponse);
             }
         }
     }

--- a/Examples/MovieProject/MovieProject.Tests/MovieProject.IsolatedTests/ComponentTesting/SearchUserHappyTests.cs
+++ b/Examples/MovieProject/MovieProject.Tests/MovieProject.IsolatedTests/ComponentTesting/SearchUserHappyTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using IsolatedTests.ComponentTestings;
+using MovieProject.Logic.DTO.MovieProject.Logic.Proxy.DTO;
+using Newtonsoft.Json;
+using SystemTestingTools;
+using Xunit;
+
+namespace MovieProject.IsolatedTests.ComponentTesting
+{
+    [Collection("SharedServer collection")]
+    [Trait("Project", "User Component Tests (Happy)")]
+    public class SearchUserHappyTests
+    {
+        private readonly TestServerFixture Fixture;
+
+        private static string Url = "https://jsonplaceholder.typicode.com/searchUsers";
+
+        public SearchUserHappyTests(TestServerFixture fixture)
+        {        
+            Fixture = fixture;
+        }
+        
+        [Fact]
+        public async Task When_UserSearchesWithValidParameters_Then_ReturnListProperly()
+        {
+            // arrange
+            var complexParameter = new UserSearchModel
+            {
+                Username = "Bret",
+            };
+            var serialisedComplexParameters = JsonConvert.SerializeObject(complexParameter);
+            var expectedResponse = new List<string>()
+            {
+                "Leanne Graham"
+            };
+            
+            var client = Fixture.Server.CreateClient();
+            client.CreateSession();
+            var response = ResponseFactory.FromFiddlerLikeResponseFile($"{Fixture.StubsFolder}/UserApi/Real_Responses/Happy/200_SearchListUsers.txt");
+
+            client.AppendHttpCallStub(HttpMethod.Get, new System.Uri(@$"{Url}?userSearchModel={serialisedComplexParameters}"), response);
+
+            // act
+            var httpResponse = await client.GetAsync("/api/users");
+
+            using (new AssertionScope())
+            {
+                // assert logs
+                var logs = client.GetSessionLogs();
+                logs.Should().BeEmpty();
+
+                // assert outgoing
+                var outgoingRequests = client.GetSessionOutgoingRequests();
+                outgoingRequests.Count.Should().Be(1);
+                outgoingRequests[0].GetEndpoint().Should().Be($"GET {Url}");
+                outgoingRequests[0].GetHeaderValue("Referer").Should().Be(MovieProject.Logic.Constants.Website);
+
+                // assert return
+                httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+                var list = await httpResponse.ReadJsonBody<List<string>>();
+                list.Count.Should().Be(1);
+                list.Should().BeEquivalentTo(expectedResponse);
+            }
+        }
+    }
+}

--- a/Examples/MovieProject/MovieProject.Web/Controllers/UserController.cs
+++ b/Examples/MovieProject/MovieProject.Web/Controllers/UserController.cs
@@ -2,6 +2,9 @@
 using MovieProject.Logic;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using MovieProject.Logic.DTO.MovieProject.Logic.Proxy.DTO;
+using MovieProject.Logic.Extensions;
+using MovieProject.Logic.Service;
 
 namespace MovieProject.Web.Controllers
 {
@@ -21,6 +24,14 @@ namespace MovieProject.Web.Controllers
         {
             // second controller with separate dependency used for testing SystemTestingTools
             return await _userService.GetUsers();
+        }      
+
+        [HttpPost("searchUsers")]
+        public async Task<List<string>> GetSearchUsers([FromBody] UserSearchModel searchModel)
+        {
+            var proxyDtoSearchModel = searchModel.MapUserSearchModelDtoToProxyDto();
+            // second controller with separate dependency used for testing SystemTestingTools
+            return await _userService.GetSearchUsers(proxyDtoSearchModel);
         }      
     }
 }


### PR DESCRIPTION
Hey @AlanCS,

As per our discussion in the [issue](https://github.com/AlanCS/SystemTestingTools/issues/16), I have finally gotten around to adding an example to the repository. I have been able to replicate the error via a test I have added when `SetEndpoint` and eventually `GetEndpoint` are invoked for the endpoint passed to `AppendHttpCallStub`.

Please take a look at this and let me know if you need anything more to work off. Thank you in advance.

PS: 
The issue is because `{` & `}` are special characters for `string.Format` and thus need to be escaped when passed to `string.Format`.
![image](https://github.com/AlanCS/SystemTestingTools/assets/45556912/c4003a75-a3d7-465a-8453-c3d1c42c5406)



