### PR TITLE
Fix pipeline by installing .net core 3.1

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -45,6 +45,10 @@ jobs:
         }    
         echo "::set-output name=VERSION::$version"
         Write-Host "$env:GITHUB_EVENT_NAME ($env:GITHUB_REF) generated version $version"
+    - name: Setup .NET core 3.1.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '3.1.x'
     - uses: actions/checkout@v2
     - name: Create folder
       run:  mkdir BuildReports


### PR DESCRIPTION
the latest version of the windows builder doesn't have .net core 3.1 pre installed, so we install it manually